### PR TITLE
issue reporting issues

### DIFF
--- a/wowhowunintuitive
+++ b/wowhowunintuitive
@@ -1,0 +1,6 @@
+the name of the irc channel for Glade isnt available on 
+https://glade.gnome.org/index.html and there is no contact page
+and issues page isn't open on github so it is almost 
+impossible to let the Glade team know about anything. 
+I'm also shocked there is no repo .deb file or appimage for glade to
+make it easy to just download and run like the windows binary


### PR DESCRIPTION
please fix the fact that the name of the irc channel for Glade isnt available on 
https://glade.gnome.org/index.html and there is no contact page
and issues page isn't open on github so it is almost 
impossible to let the Glade team know about anything. 
I'm also shocked there is no repo .deb file or appimage for glade to
make it easy to just download and run like the windows binary