### PR TITLE
bug fix - 742053

### DIFF
--- a/plugins/gtk+/glade-button-editor.c
+++ b/plugins/gtk+/glade-button-editor.c
@@ -142,7 +142,6 @@ glade_button_editor_load (GladeEditable * editable, GladeWidget * widget)
       gboolean modify_content = TRUE;
 
       if (GTK_IS_MENU_BUTTON (button) ||
-	  GTK_IS_LINK_BUTTON (button) ||
 	  GTK_IS_SCALE_BUTTON (button))
 	modify_content = FALSE;
 


### PR DESCRIPTION
Provided label field for gtk_linkbutton

**Issue reference**
[742053](https://bugzilla.gnome.org/show_bug.cgi?id=742053)

**Image after fixing the issue:**
![bugfix 2018-01-25 20-32-42](https://user-images.githubusercontent.com/30214122/35394922-fec0e9ca-020e-11e8-86b7-cd2bb96ad3ea.png)
